### PR TITLE
feat: Add new BarPlot struct with orientation field; deprecate VerticalBarPlot and HorizontalBarPlot

### DIFF
--- a/src/aesthetics/mod.rs
+++ b/src/aesthetics/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod line;
 pub(crate) mod mark;
+pub(crate) mod orientation;

--- a/src/aesthetics/orientation.rs
+++ b/src/aesthetics/orientation.rs
@@ -1,0 +1,22 @@
+use plotly::common::Orientation as OrientationPlotly;
+
+/// Enumeration representing the orientation of the legend.
+#[derive(Clone)]
+pub enum Orientation {
+    Horizontal,
+    Vertical,
+}
+
+impl Orientation {
+    /// Converts `Orientation` to the corresponding `OrientationPlotly` from the `plotly` crate.
+    ///
+    /// # Returns
+    ///
+    /// Returns the corresponding `OrientationPlotly`.
+    pub fn get_orientation(&self) -> OrientationPlotly {
+        match self {
+            Self::Horizontal => OrientationPlotly::Horizontal,
+            Self::Vertical => OrientationPlotly::Vertical,
+        }
+    }
+}

--- a/src/legend/mod.rs
+++ b/src/legend/mod.rs
@@ -1,6 +1,4 @@
-use plotly::common::Orientation as OrientationPlotly;
-
-use crate::Rgb;
+use crate::{Orientation, Rgb};
 
 /// A structure representing a customizable plot legend with properties such as background color, border, font, orientation, and position.
 ///
@@ -145,26 +143,5 @@ impl Legend {
     pub fn y(mut self, y: f64) -> Self {
         self.y = Some(y);
         self
-    }
-}
-
-/// Enumeration representing the orientation of the legend.
-#[derive(Clone)]
-pub enum Orientation {
-    Horizontal,
-    Vertical,
-}
-
-impl Orientation {
-    /// Converts `Orientation` to the corresponding `OrientationPlotly` from the `plotly` crate.
-    ///
-    /// # Returns
-    ///
-    /// Returns the corresponding `OrientationPlotly`.
-    pub fn get_orientation(&self) -> OrientationPlotly {
-        match self {
-            Self::Horizontal => OrientationPlotly::Horizontal,
-            Self::Vertical => OrientationPlotly::Vertical,
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,13 @@ mod texts;
 mod traces;
 mod traits;
 
-pub use crate::aesthetics::line::LineType;
+pub use crate::aesthetics::{line::LineType, orientation::Orientation};
 pub use crate::axis::{Axis, AxisPosition, AxisType, TickDirection, ValueExponent};
 pub use crate::colors::Rgb;
-pub use crate::legend::{Legend, Orientation};
+pub use crate::legend::Legend;
 pub use crate::texts::Text;
-pub use crate::traces::barplot::{HorizontalBarPlot, VerticalBarPlot};
+// pub use crate::traces::barplot::{BarPlot, HorizontalBarPlot, VerticalBarPlot};
+pub use crate::traces::barplot::BarPlot;
 pub use crate::traces::boxplot::{HorizontalBoxPlot, VerticalBoxPlot};
 pub use crate::traces::histogram::Histogram;
 pub use crate::traces::lineplot::LinePlot;

--- a/src/traces/barplot.rs
+++ b/src/traces/barplot.rs
@@ -3,10 +3,12 @@
 //! The `VerticalBarPlot` and `HorizontalBarPlot` structs allow for the creation and customization of bar plots
 //! with various options for data, layout, and aesthetics.
 
+#![allow(deprecated)]
+
 use bon::bon;
 
 use plotly::{
-    common::{ErrorData, ErrorType, Line as LinePlotly, Marker, Orientation},
+    common::{ErrorData, ErrorType, Line as LinePlotly, Marker, Orientation as OrientationPlotly},
     layout::BarMode,
     Bar, Layout, Trace as TracePlotly,
 };
@@ -18,9 +20,287 @@ use crate::{
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
-    Axis, Legend,
+    Axis, Legend, Orientation,
 };
 
+/// A structure representing a bar plot.
+pub struct BarPlot {
+    traces: Vec<Box<dyn TracePlotly + 'static>>,
+    layout: Layout,
+}
+
+#[bon]
+impl BarPlot {
+    /// Creates a new `BarPlot`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A reference to the `DataFrame` containing the data to be plotted.
+    /// * `values` - A string specifying the column name to be used for the y-axis (the dependent variable).
+    /// * `labels` - A string specifying the column name to be used for the x-axis (the independent variable).
+    /// * `orientation` - An optional `Orientation` enum specifying whether the plot should be horizontal or vertical.
+    /// * `group` - An optional string specifying the column name to be used for grouping data points.
+    /// * `error` - An optional string specifying the column name containing error values for the y-axis data.
+    /// * `colors` - An optional vector of `Rgb` values specifying the colors to be used for the plot.
+    /// * `plot_title` - An optional `Text` struct specifying the title of the plot.
+    /// * `x_title` - An optional `Text` struct specifying the title of the x-axis.
+    /// * `y_title` - An optional `Text` struct specifying the title of the y-axis.
+    /// * `legend_title` - An optional `Text` struct specifying the title of the legend.
+    /// * `x_axis` - An optional reference to an `Axis` struct for customizing the x-axis.
+    /// * `y_axis` - An optional reference to an `Axis` struct for customizing the y-axis.
+    ///
+    /// # Returns
+    ///
+    /// Returns an instance of `BarPlot`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// BarPlot::builder()
+    ///     .data(&dataset)
+    ///     .labels("animals")
+    ///     .values("values")
+    ///     .orientation(Orientation::Vertical)
+    ///     .group("gender")
+    ///     .error("errors")
+    ///     .colors(vec![
+    ///         Rgb(255, 0, 0),
+    ///     ])
+    ///     .plot_title(
+    ///         Text::from("Vertical Bar Plot")
+    ///             .font("Arial")
+    ///             .size(18)
+    ///     )
+    ///     .x_title(
+    ///         Text::from("animal")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .y_title(
+    ///         Text::from("value")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .legend_title(
+    ///         Text::from("gender")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .build()
+    ///     .plot();
+    /// ```
+    ///
+    /// ![Vertical Bar Plot](https://imgur.com/Fd6DpB0.png)
+    ///
+    /// ```
+    /// BarPlot::builder()
+    ///     .data(&dataset)
+    ///     .labels("animals")
+    ///     .values("values")
+    ///     .orientation(Orientation::Horizontal)
+    ///     .group("gender")
+    ///     .error("errors")
+    ///     .colors(vec![Rgb(255, 0, 0), Rgb(0, 255, 0)])
+    ///     .plot_title(
+    ///         Text::from("Horizontal Bar Plot")
+    ///             .font("Arial")
+    ///             .size(18)
+    ///     )
+    ///     .x_title(
+    ///         Text::from("value")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .y_title(
+    ///         Text::from("animal")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .legend_title(
+    ///         Text::from("gender")
+    ///             .font("Arial")
+    ///             .size(15)
+    ///     )
+    ///     .build()
+    ///     .plot();
+    /// ```
+    ///
+    /// ![Horizontal Bar Plot](https://imgur.com/saoTcNg.png)
+    #[builder(on(String, into), on(Text, into))]
+    pub fn new(
+        data: &DataFrame,
+        values: String,
+        labels: String,
+        orientation: Option<Orientation>,
+        group: Option<String>,
+        error: Option<String>,
+        // Marker
+        colors: Option<Vec<Rgb>>,
+        // Layout
+        plot_title: Option<Text>,
+        x_title: Option<Text>,
+        y_title: Option<Text>,
+        legend_title: Option<Text>,
+        x_axis: Option<&Axis>,
+        y_axis: Option<&Axis>,
+        legend: Option<&Legend>,
+    ) -> Self {
+        let value_column = values.as_str();
+        let label_column = labels.as_str();
+
+        // Layout
+        let bar_mode = Some(BarMode::Group);
+
+        let layout = Self::create_layout(
+            bar_mode,
+            plot_title,
+            x_title,
+            x_axis,
+            y_title,
+            y_axis,
+            legend_title,
+            legend,
+        );
+
+        // Trace
+        let box_points = None;
+        let point_offset = None;
+        let jitter = None;
+        let additional_series = None;
+
+        let opacity = None;
+        let size = None;
+        let line_types = None;
+
+        let traces = Self::create_traces(
+            data,
+            value_column,
+            label_column,
+            orientation,
+            group,
+            error,
+            box_points,
+            point_offset,
+            jitter,
+            additional_series,
+            opacity,
+            size,
+            colors,
+            line_types,
+        );
+
+        Self { traces, layout }
+    }
+}
+
+impl LayoutPlotly for BarPlot {}
+impl Polar for BarPlot {}
+impl Mark for BarPlot {}
+impl Line for BarPlot {}
+
+impl Trace for BarPlot {
+    fn create_trace(
+        data: &DataFrame,
+        x_col: &str,
+        y_col: &str,
+        orientation: Option<Orientation>,
+        group_name: Option<&str>,
+        error: Option<String>,
+        #[allow(unused_variables)] box_points: Option<bool>,
+        #[allow(unused_variables)] point_offset: Option<f64>,
+        #[allow(unused_variables)] jitter: Option<f64>,
+        marker: Marker,
+        #[allow(unused_variables)] line: LinePlotly,
+    ) -> Box<dyn TracePlotly + 'static> {
+        let value_data = Self::get_numeric_column(data, x_col);
+        let category_data = Self::get_string_column(data, y_col);
+
+        match orientation {
+            Some(orientation) => match orientation {
+                Orientation::Vertical => {
+                    let mut trace = Bar::default()
+                        .x(category_data)
+                        .y(value_data)
+                        .orientation(orientation.get_orientation());
+
+                    if let Some(error) = error {
+                        let error = Self::get_numeric_column(data, error.as_str())
+                            .iter()
+                            .map(|x| x.unwrap() as f64)
+                            .collect::<Vec<_>>();
+
+                        trace = trace.error_y(ErrorData::new(ErrorType::Data).array(error))
+                    }
+
+                    trace = trace.marker(marker);
+
+                    if let Some(name) = group_name {
+                        trace = trace.name(name);
+                    }
+
+                    trace
+                }
+                Orientation::Horizontal => {
+                    let mut trace = Bar::default()
+                        .x(value_data)
+                        .y(category_data)
+                        .orientation(orientation.get_orientation());
+
+                    if let Some(error) = error {
+                        let error = Self::get_numeric_column(data, error.as_str())
+                            .iter()
+                            .map(|x| x.unwrap() as f64)
+                            .collect::<Vec<_>>();
+
+                        trace = trace.error_x(ErrorData::new(ErrorType::Data).array(error))
+                    }
+
+                    trace = trace.marker(marker);
+
+                    if let Some(name) = group_name {
+                        trace = trace.name(name);
+                    }
+
+                    trace
+                }
+            },
+            None => {
+                let mut trace = Bar::default().x(category_data).y(value_data);
+
+                if let Some(error) = error {
+                    let error = Self::get_numeric_column(data, error.as_str())
+                        .iter()
+                        .map(|x| x.unwrap() as f64)
+                        .collect::<Vec<_>>();
+
+                    trace = trace.error_y(ErrorData::new(ErrorType::Data).array(error))
+                }
+
+                trace = trace.marker(marker);
+
+                if let Some(name) = group_name {
+                    trace = trace.name(name);
+                }
+
+                trace
+            }
+        }
+    }
+}
+
+impl Plot for BarPlot {
+    fn get_layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    fn get_traces(&self) -> &Vec<Box<dyn TracePlotly + 'static>> {
+        &self.traces
+    }
+}
+#[deprecated(
+    since = "0.5.0",
+    note = "`VerticalBarPlot` will be removed in v0.6.0. Please use `BarPlot` instead."
+)]
 /// A structure representing a vertical bar plot.
 pub struct VerticalBarPlot {
     traces: Vec<Box<dyn TracePlotly + 'static>>,
@@ -127,6 +407,7 @@ impl VerticalBarPlot {
         let point_offset = None;
         let jitter = None;
         let additional_series = None;
+        let orientation = None;
 
         let opacity = None;
         let size = None;
@@ -136,6 +417,7 @@ impl VerticalBarPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -162,6 +444,7 @@ impl Trace for VerticalBarPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,
@@ -204,6 +487,10 @@ impl Plot for VerticalBarPlot {
     }
 }
 
+#[deprecated(
+    since = "0.5.0",
+    note = "`HorizontalBarPlot` will be removed in v0.6.0. Please use `BarPlot` instead."
+)]
 /// A structure representing a horizontal bar plot.
 pub struct HorizontalBarPlot {
     traces: Vec<Box<dyn TracePlotly + 'static>>,
@@ -311,6 +598,7 @@ impl HorizontalBarPlot {
         let point_offset = None;
         let jitter = None;
         let additional_series = None;
+        let orientation = None;
 
         let opacity = None;
         let size = None;
@@ -320,6 +608,7 @@ impl HorizontalBarPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -346,6 +635,7 @@ impl Trace for HorizontalBarPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,
@@ -360,7 +650,7 @@ impl Trace for HorizontalBarPlot {
         let mut trace = Bar::default()
             .x(x_data)
             .y(y_data)
-            .orientation(Orientation::Horizontal);
+            .orientation(OrientationPlotly::Horizontal);
 
         if let Some(error) = error {
             let error = Self::get_numeric_column(data, error.as_str())

--- a/src/traces/boxplot.rs
+++ b/src/traces/boxplot.rs
@@ -7,14 +7,14 @@ use bon::bon;
 
 use plotly::{
     box_plot::BoxPoints,
-    common::{Line as LinePlotly, Marker, Orientation},
+    common::{Line as LinePlotly, Marker, Orientation as OrientationPlotly},
     BoxPlot, Layout, Trace as TracePlotly,
 };
 
 use polars::frame::DataFrame;
 
 use crate::{
-    aesthetics::{line::Line, mark::Mark},
+    aesthetics::{line::Line, mark::Mark, orientation::Orientation},
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
@@ -135,6 +135,7 @@ impl VerticalBoxPlot {
         );
 
         // Trace
+        let orientation = None;
         let error = None;
         let additional_series = None;
 
@@ -145,6 +146,7 @@ impl VerticalBoxPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -171,6 +173,7 @@ impl Trace for VerticalBoxPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         box_points: Option<bool>,
@@ -334,6 +337,7 @@ impl HorizontalBoxPlot {
         );
 
         // Trace
+        let orientation = None;
         let error = None;
         let additional_series = None;
 
@@ -344,6 +348,7 @@ impl HorizontalBoxPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -370,6 +375,7 @@ impl Trace for HorizontalBoxPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         box_points: Option<bool>,
@@ -384,7 +390,7 @@ impl Trace for HorizontalBoxPlot {
         let mut trace = BoxPlot::default()
             .x(x_data)
             .y(y_data)
-            .orientation(Orientation::Horizontal);
+            .orientation(OrientationPlotly::Horizontal);
 
         if let Some(all) = box_points {
             if all {

--- a/src/traces/histogram.rs
+++ b/src/traces/histogram.rs
@@ -14,7 +14,7 @@ use crate::{
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
-    Axis, Legend,
+    Axis, Legend, Orientation,
 };
 
 /// A structure representing a histogram.
@@ -119,6 +119,7 @@ impl Histogram {
 
         // Trace
         let y_col = "";
+        let orientation = None;
         let error = None;
         let box_points = None;
         let point_offset = None;
@@ -132,6 +133,7 @@ impl Histogram {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -158,6 +160,7 @@ impl Trace for Histogram {
         data: &DataFrame,
         x_col: &str,
         #[allow(unused_variables)] y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,

--- a/src/traces/lineplot.rs
+++ b/src/traces/lineplot.rs
@@ -17,7 +17,7 @@ use crate::{
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
-    Axis, Legend,
+    Axis, Legend, Orientation,
 };
 
 /// A structure representing a line plot.
@@ -131,6 +131,7 @@ impl LinePlot {
         );
 
         // Trace
+        let orientation = None;
         let group = None;
         let error = None;
         let box_points = None;
@@ -142,6 +143,7 @@ impl LinePlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -168,6 +170,7 @@ impl Trace for LinePlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,
@@ -198,6 +201,7 @@ impl Trace for LinePlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        orientation: Option<Orientation>,
         #[allow(unused_variables)] group: Option<String>,
         error: Option<String>,
         box_points: Option<bool>,
@@ -223,6 +227,7 @@ impl Trace for LinePlot {
             data,
             x_col,
             y_col,
+            orientation.clone(),
             group_name,
             error.clone(),
             box_points,
@@ -255,6 +260,7 @@ impl Trace for LinePlot {
                     &subset,
                     x_col,
                     series,
+                    orientation.clone(),
                     group_name,
                     error.clone(),
                     box_points,

--- a/src/traces/scatterplot.rs
+++ b/src/traces/scatterplot.rs
@@ -12,7 +12,7 @@ use crate::{
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
-    Axis, Legend,
+    Axis, Legend, Orientation,
 };
 
 /// A structure representing a scatter plot.
@@ -124,6 +124,7 @@ impl ScatterPlot {
         );
 
         // Trace
+        let orientation = None;
         let error = None;
         let box_points = None;
         let point_offset = None;
@@ -135,6 +136,7 @@ impl ScatterPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -161,6 +163,7 @@ impl Trace for ScatterPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,

--- a/src/traces/timeseriesplot.rs
+++ b/src/traces/timeseriesplot.rs
@@ -17,7 +17,7 @@ use crate::{
     colors::Rgb,
     texts::Text,
     traits::{layout::LayoutPlotly, plot::Plot, polar::Polar, trace::Trace},
-    Axis, Legend,
+    Axis, Legend, Orientation,
 };
 
 /// A structure representing a time series plot.
@@ -131,6 +131,7 @@ impl TimeSeriesPlot {
         );
 
         // Trace
+        let orientation = None;
         let group = None;
         let error = None;
         let box_points = None;
@@ -142,6 +143,7 @@ impl TimeSeriesPlot {
             data,
             x_col,
             y_col,
+            orientation,
             group,
             error,
             box_points,
@@ -168,6 +170,7 @@ impl Trace for TimeSeriesPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        #[allow(unused_variables)] orientation: Option<Orientation>,
         group_name: Option<&str>,
         #[allow(unused_variables)] error: Option<String>,
         #[allow(unused_variables)] box_points: Option<bool>,
@@ -198,6 +201,7 @@ impl Trace for TimeSeriesPlot {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        orientation: Option<Orientation>,
         #[allow(unused_variables)] group: Option<String>,
         error: Option<String>,
         box_points: Option<bool>,
@@ -223,6 +227,7 @@ impl Trace for TimeSeriesPlot {
             data,
             x_col,
             y_col,
+            orientation.clone(),
             group_name,
             error.clone(),
             box_points,
@@ -255,6 +260,7 @@ impl Trace for TimeSeriesPlot {
                     &subset,
                     x_col,
                     series,
+                    orientation.clone(),
                     group_name,
                     error.clone(),
                     box_points,

--- a/src/traits/trace.rs
+++ b/src/traits/trace.rs
@@ -7,7 +7,7 @@ use polars::frame::DataFrame;
 
 use crate::{
     aesthetics::{line::Line, mark::Mark},
-    LineType, Rgb,
+    LineType, Orientation, Rgb,
 };
 
 use crate::traits::polar::Polar;
@@ -18,6 +18,7 @@ pub(crate) trait Trace: Polar + Mark + Line {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        orientation: Option<Orientation>,
         group_name: Option<&str>,
         error: Option<String>,
         box_points: Option<bool>,
@@ -32,6 +33,7 @@ pub(crate) trait Trace: Polar + Mark + Line {
         data: &DataFrame,
         x_col: &str,
         y_col: &str,
+        orientation: Option<Orientation>,
         group: Option<String>,
         error: Option<String>,
         box_points: Option<bool>,
@@ -67,6 +69,7 @@ pub(crate) trait Trace: Polar + Mark + Line {
                         &subset,
                         x_col,
                         y_col,
+                        orientation.clone(),
                         Some(group_name),
                         error.clone(),
                         box_points,
@@ -88,6 +91,7 @@ pub(crate) trait Trace: Polar + Mark + Line {
                     data,
                     x_col,
                     y_col,
+                    orientation,
                     group_name,
                     error,
                     box_points,


### PR DESCRIPTION
- Introduced a new BarPlot struct with an orientation field to handle both vertical and horizontal bar plots.
- Marked VerticalBarPlot and HorizontalBarPlot as deprecated, to be removed in version 0.6.0.