### PR TITLE
Allow flexible polars version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ categories = ["visualization"]
 bon = "3.3.2"
 image = "0.25.5"
 plotly = "0.12.1"
-polars = { version = "0.45.1", features = ["lazy", "strings"] }
+polars = { version = ">=0.45.1", features = ["lazy", "strings"] }
 serde = "1.0.217"
 serde_json = "1.0.134"


### PR DESCRIPTION
Very cool crate!

# Goal

Unpin the version of Polars to be more flexible and make the Polars Rust ecosystem more compatible.

# Issue

When the `Polars` version is pinned (like to `0.45.1` in this crate), it makes it impossible to work between many crates. For example, this code below does not work because `hypors` pins Polars to `0.43.1` and `Plotlars` pins Polars to `0.45.1`, making `Polars` incompatible (and I need 0.46 for my project). Using the first `Cargo.toml`, it throws an error and suggests `perhaps two different versions of crate `polars_core` are being used?`. Using the second (with this pull request and a similar pull request for [Hypors](https://github.com/astronights/hypors/pull/3) there is no issue since both crates are actually compatible with `Polars 0.46`. 

Example code using Polars, Hypors and Plotlars: 

```Rust
use hypors::anova::anova;
use plotlars::{Plot, Rgb, ScatterPlot};
use polars::prelude::*;

fn main() {
    // https://github.com/alceal/plotlars/blob/main/data/penguins.csv
    let lf = LazyCsvReader::new("./penguins.csv")
        .with_has_header(true)
        .finish()
        .unwrap();

    // Plot to explore the data
    let html = ScatterPlot::builder()
        .data(&lf.clone().collect().unwrap())
        .x("body_mass_g")
        .y("flipper_length_mm")
        .group("species")
        .opacity(0.5)
        .size(12)
        .colors(vec![Rgb(178, 34, 34), Rgb(65, 105, 225), Rgb(255, 140, 0)])
        .plot_title("Penguin Flipper Length vs Body Mass")
        .x_title("Body Mass (g)")
        .y_title("Flipper Length (mm)")
        .legend_title("Species")
        .build()
        .to_html();

    // Write HTML
    let mut file = std::fs::File::create("./plot.html").unwrap();
    std::io::Write::write_all(&mut file, html.as_bytes()).unwrap();

    // Reduce lf to only needed variables and process vars
    let lf = lf
        .select([
            col("species"),
            col("flipper_length_mm").cast(DataType::Float64),
        ])
        .filter(col("flipper_length_mm").is_not_null())
        .with_row_index("index", None);

    // Transpose for ANOVA
    let df = pivot::pivot_stable(
        &lf.collect().unwrap(),
        ["species"],
        Some(["index"]),
        Some(["flipper_length_mm"]),
        false,
        None,
        None,
    )
    .unwrap()
    .drop("index")
    .unwrap();

    // Create Vec<Series> for ANOVA
    let cols: Vec<Series> = df
        .get_columns()
        .iter()
        .map(|c| c.as_materialized_series().to_float().unwrap().drop_nulls())
        .collect();

    // Perform one-way ANOVA
    let result = anova(&[&cols[0], &cols[1], &cols[2]], 0.05).unwrap();

    println!(
        "\nF-statistic: {}\np-value: {}\n",
        result.test_statistic, result.p_value
    );
}
```

`Cargo.toml` no. 1:

```toml
polars = { version = "0.46", features = ["lazy", "parquet", "pivot"] }
hypors = "0.2.5"
plotlars = "0.8.1"
```


`Cargo.toml` no. 2:

```toml
polars = { version = "0.46", features = ["lazy", "parquet", "pivot"] }
hypors = {git = "https://github.com/EricFecteau/hypors.git", branch = "Update-Polars" }
plotlars = {git = "https://github.com/EricFecteau/plotlars.git", branch = "update_polars" }
```
