### PR TITLE
Add dependency on plotters in LinePlot docs

### DIFF
--- a/src/plots/lineplot.rs
+++ b/src/plots/lineplot.rs
@@ -64,6 +64,7 @@ use crate::{
 /// ```rust
 /// use ndarray::Array;
 ///
+/// use plotters::prelude::*;
 /// use plotlars::{Axis, Line, LinePlot, Plot, Rgb, Text, TickDirection};
 ///
 /// let x_values: Array<f64, _> = Array::linspace(0.0, 2.0 * std::f64::consts::PI, 1000);


### PR DESCRIPTION
In the [example](https://github.com/alceal/plotlars/blob/main/examples/lineplot.rs#L2) the dependency on `plotters` is explicit, whereas in the documentation it is not. This caused some confusion when I was trying to create a LinePlot. In addition, compiler was complaining that the type needed for the `DataFrame` needs to be `Column` instead of `Series`