### PR TITLE
fix: incorrect import in the README example (Text unused; Rgb missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Now, compare that to the same plot created **using Plotlars**:
 use plotlars::{
     ScatterPlot,
     Plot,
-    Text,
+    Rgb,
 };
 
 use polars::prelude::*;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example code in the README to use `Rgb` for color values, improving clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->